### PR TITLE
fix: block access to login & register pages for authenticated users via browser back 

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,7 +1,24 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import LoginForm from './LoginForm';
+import { useAuth } from '@/context/AuthContext';
 
 const Login = (): JSX.Element | null => {
+  const router = useRouter();
+  const { isAuthenticated } = useAuth();
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      router.replace('/');
+    }
+  }, [isAuthenticated, router]);
+
+  if (isAuthenticated) return null;
+
   return (
     <div className="flex w-full items-center justify-center p-4 sm:p-8">
       <Card className="flex flex-col items-center justify-center p-5 sm:px-12 sm:py-8 w-full max-w-lg bg-white shadow-lg rounded-xl">

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,6 +1,23 @@
-import RegisterForm from '@/components/Register/Form/RegisterForm';
+'use client';
 
-const Register = (): JSX.Element => {
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+import RegisterForm from '@/components/Register/Form/RegisterForm';
+import { useAuth } from '@/context/AuthContext';
+
+const Register = (): JSX.Element | null => {
+  const router = useRouter();
+  const { isAuthenticated } = useAuth();
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      router.replace('/');
+    }
+  }, [isAuthenticated, router]);
+
+  if (isAuthenticated) return null;
+
   return (
     <div className="flex items-center justify-center p-4 sm:p-8 w-full">
       <RegisterForm />

--- a/tests/pages/register.test.tsx
+++ b/tests/pages/register.test.tsx
@@ -6,6 +6,18 @@ jest.mock('@/components/Register/Form/RegisterForm', () => ({
   default: jest.fn(() => <div>RegisterForm</div>)
 }));
 
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: jest.fn()
+  })
+}));
+
+jest.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({
+    isAuthenticated: false
+  })
+}));
+
 describe('Register', () => {
   it('should render all components', () => {
     render(<Register />);


### PR DESCRIPTION
### Description

Fix block access to login & register pages for authenticated users via browser back.

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Rationale for the change

Fix authenticated users redirection via browser back.

### Screenshots (if applicable)

N/A

### Checklist

- [x] The code follows the project's coding guidelines and style.
- [x] Tests have been added or updated to cover the changes (if applicable).
- [x] All new and existing tests pass successfully.
- [x] The branch is up-to-date with the latest changes from the target branch.

### Related Issues

- Fixes [RSS-ECOMM-2_06](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint2/RSS-ECOMM-2_06.md)

### Additional Notes (Optional)

N/A
