### PR TITLE
Hotfix: multiple password changes now work correctly.

### DIFF
--- a/src/components/Profile/details/PasswordChange.tsx
+++ b/src/components/Profile/details/PasswordChange.tsx
@@ -8,8 +8,9 @@ import FormField from '@/components/Register/Form/FieldForm';
 import { Button } from '@/components/ui/button';
 import { passwordSchema } from '@/components/Register/RegisterSchema';
 import { handleErrors } from '@/components/Register/registerUtils';
-import updateUserPassword from './updatePassword';
 import { useAuth } from '@/context/AuthContext';
+import updateUserPassword from './updatePassword';
+import reauthenticate from './reauth';
 
 const validationSchema = Yup.object({
   currentPassword: passwordSchema,
@@ -51,21 +52,8 @@ const PasswordChange = (): JSX.Element => {
                 version: user.version
               });
 
-              const authResponse = await fetch('/api/auth/login', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                  email: user.email,
-                  password: values.newPassword
-                }),
-                credentials: 'include'
-              });
+              await reauthenticate(user.email, values.newPassword);
 
-              if (!authResponse.ok) {
-                const err = await authResponse.json();
-                throw new Error(err.message || 'Failed to reauthenticate');
-              }
-              await new Promise((resolve) => setTimeout(resolve, 500));
               await refreshUser();
               resetForm();
               toast.success('Password updated successfully!');

--- a/src/components/Profile/details/PasswordChange.tsx
+++ b/src/components/Profile/details/PasswordChange.tsx
@@ -65,7 +65,7 @@ const PasswordChange = (): JSX.Element => {
                 const err = await authResponse.json();
                 throw new Error(err.message || 'Failed to reauthenticate');
               }
-
+              await new Promise((resolve) => setTimeout(resolve, 500));
               await refreshUser();
               resetForm();
               toast.success('Password updated successfully!');

--- a/src/components/Profile/details/reauth.ts
+++ b/src/components/Profile/details/reauth.ts
@@ -1,0 +1,17 @@
+const reauthenticate = async (email: string, password: string) => {
+  await fetch('/api/auth/logout', { method: 'DELETE' });
+
+  const loginResponse = await fetch('/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+    credentials: 'include'
+  });
+
+  if (!loginResponse.ok) {
+    const err = await loginResponse.json();
+    throw new Error(err.message || 'Failed to reauthenticate');
+  }
+};
+
+export default reauthenticate;


### PR DESCRIPTION
### Description

Fixes broken session flow after changing the password more than once.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Rationale for the change

The previous implementation did not correctly handle user session state after a password was changed more than once. After the first change, subsequent changes resulted in errors due to stale tokens.

This fix explicitly logs the user out before re-authenticating with the new password, ensuring session tokens are refreshed and consistent.

### Screenshots (if applicable)


### Checklist

Before submitting this pull request, please make sure to review and check the following:

- [x] The code follows the project's coding guidelines and style.
- [x] All new and existing tests pass successfully.
- [x] The branch is up-to-date with the latest changes from the target branch.

### Related Issues

- Resolves bug with repeated password changes leading to errors.

### Additional Notes (Optional)

Tested by changing the password multiple times in a row and verifying correct reauthentication and user data update.